### PR TITLE
Add ngsPETSc.utils to the list of packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    packages=['ngsPETSc'],
+    packages=["ngsPETSc", "ngsPETSc.utils"],
     python_requires = ">=3.10",
     install_requires=install_requires
 


### PR DESCRIPTION
Before this change, installing on my system gave me the following files
```
[...]/lib/python3.11/site-packages/ngsPETSc$ ls -l
total 56
-rw------- 1 ballarin matem  6972 Oct 13 11:41 eps.py
-rw------- 1 ballarin matem   585 Oct 13 11:41 __init__.py
-rw------- 1 ballarin matem  2659 Oct 13 11:41 ksp.py
-rw------- 1 ballarin matem  6477 Oct 13 11:41 mat.py
-rw------- 1 ballarin matem  3691 Oct 13 11:41 pc.py
-rw------- 1 ballarin matem 10024 Oct 13 11:41 plex.py
drwx------ 2 ballarin matem  4096 Oct 13 11:41 __pycache__
-rw------- 1 ballarin matem  6714 Oct 13 11:41 snes.py
-rw------- 1 ballarin matem  3706 Oct 13 11:41 vec.py
```

After this change I get
```
[...]/lib/python3.11/site-packages/ngsPETSc$ cd $PWD && ls -l
total 60
-rw------- 1 ballarin matem  6972 Oct 13 11:44 eps.py
-rw------- 1 ballarin matem   585 Oct 13 11:44 __init__.py
-rw------- 1 ballarin matem  2659 Oct 13 11:44 ksp.py
-rw------- 1 ballarin matem  6477 Oct 13 11:44 mat.py
-rw------- 1 ballarin matem  3691 Oct 13 11:44 pc.py
-rw------- 1 ballarin matem 10024 Oct 13 11:44 plex.py
drwx------ 2 ballarin matem  4096 Oct 13 11:44 __pycache__
-rw------- 1 ballarin matem  6714 Oct 13 11:44 snes.py
drwx------ 3 ballarin matem  4096 Oct 13 11:44 utils
-rw------- 1 ballarin matem  3706 Oct 13 11:44 vec.py
```

Note how the `utils` subfolder is only present with the changes in this PR.