### PR TITLE
Minor improvements to GitHub actions worflows

### DIFF
--- a/.github/workflows/Docker.yml
+++ b/.github/workflows/Docker.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Login to Docker Hub
+        if: github.repository == 'NGSolve/ngsPETSc'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -24,6 +25,7 @@ jobs:
         run: |
           docker build -t ngspetsc:latest .
       - name: Push Docker image
+        if: github.repository == 'NGSolve/ngsPETSc'
         run: |
           docker tag ngspetsc:latest urzerbinati/ngspetsc:latest
           docker push urzerbinati/ngspetsc:latest

--- a/.github/workflows/Docker.yml
+++ b/.github/workflows/Docker.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 360
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/Docker.yml
+++ b/.github/workflows/Docker.yml
@@ -4,6 +4,8 @@ on:
     schedule:
     - cron:  '30 10 7,14,21,28 * *'
 
+    workflow_dispatch:
+
     push:
         paths:
         - Dockerfile

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -1,8 +1,8 @@
 # .github/workflows/app.yaml
 name: ngsPETSc tests
-on: 
+on:
     push:
-      branches-ignore:    
+      branches-ignore:
       - 'no-ci/*'
 
     schedule:
@@ -60,11 +60,11 @@ jobs:
 
       - name: Install Netgen and ngsPETSc
         run: |
-          pip3 install netgen-mesher \
-          && pip3 install pylint \
-          && export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.10/site-packages \
-          && echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV \
-          && NGSPETSC_NO_INSTALL_REQUIRED=ON pip install .
+          pip install netgen-mesher
+          pip install pylint
+          export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.10/site-packages
+          echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
+          NGSPETSC_NO_INSTALL_REQUIRED=ON pip install .
 
       - name: Check formatting
         run: |

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install ngsPETSc
         run: |
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Netgen and ngsPETSc
         run: |


### PR DESCRIPTION
* Simplify `fenicsx` job: there is no need to join all commands with `&&`, since GitHub actions has an implicit `set -e` that will make the job fail on first error.
* Bump `actions/checkout` to the latest version
* Avoid trying to push `dockerhub` from forks, since they do not have secrets available.
* Add `workflow_dispatch` to `docker` workflow: it allows to manually trigger the workflow, which may come in handy at some point in future for updating the docker image without waiting for the schedule.