### PR TITLE
Add `netgen` to `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ elif 'NGS_FROM_SOURCE' in os.environ:
         ]
 else:
     install_requires=[
+        'netgen',
         'ngsolve',
         'petsc4py',
         'mpi4py',


### PR DESCRIPTION
@drew-parsons and I have started packaging ngsPETSc for debian, and there it would be beneficial if `netgen` was listed explicitly as a dependency, rather than implicitly through `ngsolve`. We can't rely on the implicit dependency because `ngsolve` is not packaged yet on debian.