### PR TITLE
Mesh Smoothing

### DIFF
--- a/ngsPETSc/utils/firedrake.py
+++ b/ngsPETSc/utils/firedrake.py
@@ -177,6 +177,9 @@ def curveField(self, order, tol=1e-8):
 def splitToQuads(plex, dim, comm):
     '''
     This method splits a Netgen mesh to quads, using a PETSc transform.
+    TODO: Improve support quad meshing.
+        @pef  Get netgen to make a quad-dominant mesh, and then only split the triangles.
+              Current implementation will make for poor-quality meshes. 
     '''
     if dim == 2:
         transform = PETSc.DMPlexTransform().create(comm=comm)
@@ -211,7 +214,6 @@ class FiredrakeMesh:
         #Checking the mesh format
         if isinstance(mesh,(ngs.comp.Mesh,ngm.Mesh)):
             if split2tets:
-                #Splits 2 tets
                 mesh = mesh.Split2Tets()
             if split:
                 #Split mesh this includes Alfeld and Powell-Sabin

--- a/ngsPETSc/utils/firedrake.py
+++ b/ngsPETSc/utils/firedrake.py
@@ -221,7 +221,6 @@ class FiredrakeMesh:
                 #Optimises the mesh, for example smoothing
                 if mesh.dim == 2: 
                     mesh.OptimizeMesh2d(MeshingParameters(optimize2d=optMoves))
-                    print("Optimising mesh")
                 elif mesh.dim == 3:
                     mesh.OptimizeVolumeMesh(MeshingParameters(optimize3d=optMoves))
                 else:
@@ -371,6 +370,7 @@ def NetgenHierarchy(mesh, levs, flags):
         order= [order]*(levs+1)
     tol = flagsUtils(flags, "tol", 1e-8)
     refType = flagsUtils(flags, "refinement_type", "uniform")
+    optMoves = flagsUtils(flags, "optimisation_moves", False)
     #Firedrake quoantities
     meshes = []
     coarse_to_fine_cells = []
@@ -395,6 +395,14 @@ def NetgenHierarchy(mesh, levs, flags):
         #We construct a Firedrake mesh from the DMPlex mesh
         mesh = fd.Mesh(rdm, dim=meshes[-1].ufl_cell().geometric_dimension(), reorder=False,
                                     distribution_parameters=params, comm=comm)
+        if optMoves:
+            #Optimises the mesh, for example smoothing
+            if ngmesh.dim == 2: 
+                ngmesh.OptimizeMesh2d(MeshingParameters(optimize2d=optMoves))
+            elif mesh.dim == 3:
+                ngmesh.OptimizeVolumeMesh(MeshingParameters(optimize3d=optMoves))
+            else:
+                raise ValueError("Only 2D and 3D meshes can be optimised.")
         mesh.netgen_mesh = ngmesh
         #We curve the mesh
         if order[l+1] > 1:

--- a/ngsPETSc/utils/firedrake.py
+++ b/ngsPETSc/utils/firedrake.py
@@ -12,7 +12,6 @@ except ImportError:
     fd = None
 
 from fractions import Fraction
-import warnings
 import numpy as np
 from petsc4py import PETSc
 
@@ -184,10 +183,10 @@ def splitToQuads(plex, dim, comm):
         transform.setType(PETSc.DMPlexTransformType.REFINETOBOX)
         transform.setDM(plex)
         transform.setUp()
-        newplex = transform.apply(plex)
-        return newplex
     else:
         raise RuntimeError("Splitting to quads is only possible for 2D meshes.")
+    newplex = transform.apply(plex)
+    return newplex
 
 splitTypes = {"Alfeld": lambda x: x.SplitAlfeld(),
               "Powell-Sabin": lambda x: x.SplitPowellSabin()}
@@ -219,7 +218,7 @@ class FiredrakeMesh:
                 splitTypes[split](mesh)
             if optMoves:
                 #Optimises the mesh, for example smoothing
-                if mesh.dim == 2: 
+                if mesh.dim == 2:
                     mesh.OptimizeMesh2d(MeshingParameters(optimize2d=optMoves))
                 elif mesh.dim == 3:
                     mesh.OptimizeVolumeMesh(MeshingParameters(optimize3d=optMoves))
@@ -397,7 +396,7 @@ def NetgenHierarchy(mesh, levs, flags):
                                     distribution_parameters=params, comm=comm)
         if optMoves:
             #Optimises the mesh, for example smoothing
-            if ngmesh.dim == 2: 
+            if ngmesh.dim == 2:
                 ngmesh.OptimizeMesh2d(MeshingParameters(optimize2d=optMoves))
             elif mesh.dim == 3:
                 ngmesh.OptimizeVolumeMesh(MeshingParameters(optimize3d=optMoves))


### PR DESCRIPTION
Mesh optimisation options are exposed in ngsPETSc. In particular, this allows to do mesh smoothing.
All details on the mesh optimisation features are available [here](https://forum.ngsolve.org/t/mesh-smoothing/2650/4).
Here is an example:
```
from firedrake import *
from netgen.occ import *
# Make 2D rectangle from (0, 0) to (1, 2)
rect1 = WorkPlane(Axes((0,0,0), n=Z, h=X)).Rectangle(1,2).Face()
# Make 2D rectangle from (0, 1) to (2, 2)
rect2 = WorkPlane(Axes((0,1,0), n=Z, h=X)).Rectangle(2,1).Face()
L = rect1 + rect2
geo = OCCGeometry(L, dim=2)
ngmesh = geo.GenerateMesh(maxh=0.1)
mesh = Mesh(ngmesh, netgen_flags={"optimisation_moves": "mmmm"})
mh = MeshHierarchy(mesh, 3, netgen_flags={"optimisation_moves": "mmmm"})
```