### PR TITLE
Adding a netgen flag to specify the index value associated with each label

### DIFF
--- a/ngsPETSc/plex.py
+++ b/ngsPETSc/plex.py
@@ -208,14 +208,14 @@ class MeshMapping:
                 vStart, _ = plex.getDepthStratum(0)   # vertices
                 for e in self.ngMesh.Elements1D():
                     join = plex.getJoin([vStart+v.nr-1 for v in e.vertices])
-                    plex.setLabelValue(FACE_SETS_LABEL, join[0], int(e.index))
+                    if e.index in newLabels:
+                        plex.setLabelValue(FACE_SETS_LABEL, join[0], int(newLabels[e.index]))
+                    else:
+                        plex.setLabelValue(FACE_SETS_LABEL, join[0], int(e.index))
                 if not (1 == self.ngMesh.Elements2D().NumPy()["index"]).all():
                     for e in self.ngMesh.Elements2D():
                         join = plex.getFullJoin([vStart+v.nr-1 for v in e.vertices])
-                        if e.index in newLabels:
-                            plex.setLabelValue(CELL_SETS_LABEL, join[0], int(newLabels[e.index]))
-                        else:
-                            plex.setLabelValue(CELL_SETS_LABEL, join[0], int(e.index))
+                        plex.setLabelValue(CELL_SETS_LABEL, join[0], int(e.index))
                 self.petscPlex = plex
             else:
                 plex = PETSc.DMPlex().createFromCellList(2,

--- a/ngsPETSc/plex.py
+++ b/ngsPETSc/plex.py
@@ -33,11 +33,11 @@ class MeshMapping:
 
     '''
 
-    def __init__(self, mesh=None, comm=MPI.COMM_WORLD, name="Default"):
+    def __init__(self, mesh=None, comm=MPI.COMM_WORLD, name="default", labels={}): #pylint: disable=W0102
         self.name = name
         self.comm = comm
         if isinstance(mesh,(ngs.comp.Mesh,ngm.Mesh)):
-            self.createPETScDMPlex(mesh)
+            self.createPETScDMPlex(mesh, labels=labels)
         elif isinstance(mesh,PETSc.DMPlex):
             self.createNGSMesh(mesh)
         else:
@@ -146,13 +146,13 @@ class MeshMapping:
         else:
             raise NotImplementedError("No implementation for dimension greater than 3.")
 
-    def createPETScDMPlex(self, mesh):
+    def createPETScDMPlex(self, mesh, labels):
         '''
         This function generate an PETSc DMPlex from a Netgen/NGSolve mesh object
 
-        :arg plex: the Netgen/NGSolve mesh object to be converted into a PETSc
+        :arg mesh: the Netgen/NGSolve mesh object to be converted into a PETSc
                    DMPlex.
-
+        :arg labels: Dictionary with the new labels for the sets.
         '''
         if isinstance(mesh,ngs.comp.Mesh):
             self.ngMesh = mesh.ngmesh
@@ -192,6 +192,14 @@ class MeshMapping:
                 self.petscPlex = plex
         elif self.ngMesh.dim == 2:
             if comm.rank == 0:
+                # Map Netgen string to ids for the labels
+                newLabels = []
+                if len(labels) > 0:
+                    for key in labels.keys():
+                        for i, s in enumerate(self.ngMesh.GetRegionNames(dim=1)):
+                            if key == s:
+                                newLabels = newLabels + [(i+1, labels[key])]
+                newLabels = dict(newLabels)
                 V = self.ngMesh.Coordinates()
                 T = self.ngMesh.Elements2D().NumPy()["nodes"]
                 T = np.array([list(np.trim_zeros(a, 'b')) for a in list(T)])-1
@@ -204,8 +212,10 @@ class MeshMapping:
                 if not (1 == self.ngMesh.Elements2D().NumPy()["index"]).all():
                     for e in self.ngMesh.Elements2D():
                         join = plex.getFullJoin([vStart+v.nr-1 for v in e.vertices])
-                        plex.setLabelValue(CELL_SETS_LABEL, join[0], int(e.index))
-
+                        if e.index in newLabels:
+                            plex.setLabelValue(CELL_SETS_LABEL, join[0], int(newLabels[e.index]))
+                        else:
+                            plex.setLabelValue(CELL_SETS_LABEL, join[0], int(e.index))
                 self.petscPlex = plex
             else:
                 plex = PETSc.DMPlex().createFromCellList(2,

--- a/ngsPETSc/utils/firedrake.py
+++ b/ngsPETSc/utils/firedrake.py
@@ -211,6 +211,7 @@ class FiredrakeMesh:
         split = flagsUtils(netgen_flags, "split", False)
         quad = flagsUtils(netgen_flags, "quad", False)
         optMoves = flagsUtils(netgen_flags, "optimisation_moves", False)
+        labels = flagsUtils(netgen_flags, "labels", {})
         #Checking the mesh format
         if isinstance(mesh,(ngs.comp.Mesh,ngm.Mesh)):
             if split2tets:
@@ -227,7 +228,7 @@ class FiredrakeMesh:
                 else:
                     raise ValueError("Only 2D and 3D meshes can be optimised.")
             #We create the plex from the netgen mesh
-            self.meshMap = MeshMapping(mesh, comm=self.comm)
+            self.meshMap = MeshMapping(mesh, comm=self.comm, labels=labels)
             #We apply the DMPLEX transform
             if quad:
                 newplex = splitToQuads(self.meshMap.petscPlex, mesh.dim, comm=self.comm)
@@ -359,7 +360,7 @@ def NetgenHierarchy(mesh, levs, flags):
         -tol, geometric tollerance adopted in snapToNetgenDMPlex.
         -refinement_type, the refinment type to be used: uniform (default), Alfeld
     '''
-    if mesh.geometric_dimension() == 3:
+    if mesh.dim == 3:
         raise NotImplementedError("Netgen hierachies are only implemented for 2D meshes.")
     ngmesh = mesh.netgen_mesh
     comm = mesh.comm


### PR DESCRIPTION
Adding a netgen flag to specify the index value associated with each label.
Here is a minimal working code.

```
from firedrake import *
from firedrake.output import VTKFile
from netgen.occ import *

rect=WorkPlane().Rectangle(2,2).Face()
circ = WorkPlane().MoveTo(1,1).Rectangle(0.5,0.5).Face()
rect.edges.name = "outer"
circ.edges.name = "inner"
shape = rect-circ
geo = OCCGeometry(shape, dim=2)
ngmesh = geo.GenerateMesh(maxh=1.)
mesh = Mesh(ngmesh, netgen_flags={"labels": {"outer": 1, "inner": 2}})
V = FunctionSpace(mesh, "CG", 1)
f = Function(V)
DirichletBC(V, -1, [1]).apply(f)
DirichletBC(V, 1, [2]).apply(f)

vtk = VTKFile("output/test_labels.pvd").write(f)
```

![image](https://github.com/NGSolve/ngsPETSc/assets/974956/2880068f-baad-4003-82f7-48cfe6f6db12)
