### PR TITLE
Snapping back to the coarse grid

### DIFF
--- a/ngsPETSc/ksp.py
+++ b/ngsPETSc/ksp.py
@@ -40,7 +40,7 @@ def createFromMatrix(a, freeDofs, solverParameters):
         mat = Matrix(a, (dofs, freeDofs, None), solverParameters["ngs_mat_type"])
         pscMat = mat.mat
         return (a, pscMat)
-    elif solverParameters["ngs_mat_type"] == "python":
+    if solverParameters["ngs_mat_type"] == "python":
         _, pscMat = createFromAction(a, freeDofs, solverParameters)
         return (a, pscMat)
     raise ValueError("ngs_mat_type {} is not supported.".format(solverParameters["ngs_mat_type"]))

--- a/ngsPETSc/ksp.py
+++ b/ngsPETSc/ksp.py
@@ -39,6 +39,7 @@ def createFromMatrix(a, freeDofs, solverParameters):
             dofs = None
         mat = Matrix(a, (dofs, freeDofs, None), solverParameters["ngs_mat_type"])
         pscMat = mat.mat
+        return (a, pscMat)
     elif solverParameters["ngs_mat_type"] == "python":
         _, pscMat = createFromAction(a, freeDofs, solverParameters)
         return (a, pscMat)

--- a/ngsPETSc/utils/firedrake/hierarchies.py
+++ b/ngsPETSc/utils/firedrake/hierarchies.py
@@ -42,21 +42,10 @@ def snapToCoarse(coarse, linear, degree):
         element = low_order_element.reconstruct(degree=degree)
         space = fd.VectorFunctionSpace(linear, fd.BrokenElement(element))
         ho = fd.assemble(interpolate(linear.coordinates, space))
-        eStart, eEnd = linear.topology_dm.getDepthStratum(1)
-        pStart, _ = linear.topology_dm.getDepthStratum(0)
-        nodes = linear.topology_dm.getCoordinatesLocal().getArray().reshape(-1, 2)
+        bnd = coarse.coordinates.function_space().boundary_nodes("on_boundary")
+        print(bnd)
         for i, pt in enumerate(ho.dat.data):
-            d = np.sum((coarse.coordinates.dat.data - pt)**2, axis=1)
-            j = np.argmin(d)
-            #check if points are on the boudnary
-            for k in range(eStart, eEnd):
-                cone = linear.topology_dm.getCone(k)
-                A = np.array([[1, nodes[cone[0]-pStart][0], nodes[cone[0]-pStart][1]],
-                              [1, nodes[cone[1]-pStart][0], nodes[cone[1]-pStart][1]],
-                              [1, pt[0], pt[1]]])
-                lb = linear.topology_dm.getLabelValue("Face Sets", k)
-                if np.abs(np.linalg.det(A)) <1e-12 and lb != -1:
-                    ho.dat.data[i] = coarse.coordinates.dat.data[j]
+            pass
     else:
         raise NotImplementedError("Snapping to Netgen meshes is only implemented for 2D meshes.")
     return fd.Mesh(ho, comm=linear.comm, distribution_parameters=linear._distribution_parameters)

--- a/ngsPETSc/utils/firedrake/meshes.py
+++ b/ngsPETSc/utils/firedrake/meshes.py
@@ -70,7 +70,7 @@ def refineMarkedElements(self, mark):
     else:
         raise NotImplementedError("No implementation for dimension other than 2 and 3.")
 
-def curveField(self, order, tol=1e-8):
+def curveField(self, order, tol=1e-8, CG=False):
     '''
     This method returns a curved mesh as a Firedrake function.
 
@@ -80,9 +80,12 @@ def curveField(self, order, tol=1e-8):
     #Checking if the mesh is a surface mesh or two dimensional mesh
     surf = len(self.netgen_mesh.Elements3D()) == 0
     #Constructing mesh as a function
-    low_order_element = self.coordinates.function_space().ufl_element().sub_elements[0]
-    element = low_order_element.reconstruct(degree=order)
-    space = fd.VectorFunctionSpace(self, fd.BrokenElement(element))
+    if CG:
+        space = fd.VectorFunctionSpace(self, "CG", order)
+    else:
+        low_order_element = self.coordinates.function_space().ufl_element().sub_elements[0]
+        element = low_order_element.reconstruct(degree=order)
+        space = fd.VectorFunctionSpace(self, fd.BrokenElement(element))
     newFunctionCoordinates = fd.assemble(interpolate(self.coordinates, space))
     #Computing reference points using fiat
     fiat_element = newFunctionCoordinates.function_space().finat_element.fiat_equivalent

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -1,12 +1,13 @@
 @article{Netgen,
-pages = {41-52},
-publisher = {Springer Science and Business Media LLC},
-volume = {1},
-year = {1997},
-title = {NETGEN An advancing front 2D/3D-mesh generator based on abstract rules},
-author = {Schöberl, Joachim},
-journal = {Computing and visualization in science},
-number = {1},
+  pages = {41-52},
+  publisher = {Springer Science and Business Media LLC},
+  volume = {1},
+  year = {1997},
+  title = {NETGEN An advancing front 2D/3D-mesh generator based on abstract rules},
+  author = {Schöberl, Joachim},
+  journal = {Computing and visualization in science},
+  number = {1},
+  doi = {10.1007/s007910050004}
 }
 @article{NGSolve,
   title={C++ 11 implementation of finite elements in NGSolve},
@@ -19,8 +20,9 @@ number = {1},
   title={Firedrake user manual},
   author={Ham, David A and Kelly, Paul HJ and Mitchell, Lawrence and Cotter, Colin J and Kirby, Robert C and Sagiyama, Koki and Bouziani, Nacime and Vorderwuelbecke, Sophia and Gregory, Thomas J and Betteridge, Jack and others},
   journal={Imperial College London and University of Oxford and Baylor University and University of Washington,},
-  volume={5},
-  year={2023}
+  month={5},
+  year={2023},
+  doi= {10.25561/104839}
 }
 @techreport{PETSc,
   author={Satish Balay and Shrirang Abhyankar and Mark~F. Adams and Steven Benson and Jed
@@ -35,7 +37,8 @@ number = {1},
   title={{PETSc/TAO} Users Manual},
   institution={Argonne National Laboratory},
   number={ANL-21/39 - Revision 3.20},
-  year={2023}
+  year={2023},
+  doi={10.2172/2205494}
 }
 @article{petsc4py,
   title={Parallel distributed computing using Python},
@@ -45,7 +48,8 @@ number = {1},
   number={9},
   pages={1124 - 1139},
   issn={0309-1708},
-  year={2011}
+  year={2011},
+  doi={10.1016/j.advwatres.2011.04.013}
 }
 @misc{manual,
   author       = {Zerbinati, Umberto},
@@ -55,7 +59,6 @@ number = {1},
   publisher    = {Zenodo},
   version      = {0.0.5},
   doi          = {10.5281/zenodo.12650574},
-  url          = {https://ngspetsc.readthedocs.io/en/latest/}
 }
 @article{PETScBDDC,
       author = {Stefano Zampini},
@@ -66,8 +69,6 @@ number = {1},
       pages = {S282-S306},
       year = {2016},
       doi = {10.1137/15M1025785},
-      URL = {http://dx.doi.org/10.1137/15M1025785},
-      eprint = {http://dx.doi.org/10.1137/15M1025785}
 }
 @article{PETScGAMG,
 title = {Parallel multigrid smoothing: polynomial versus {Gauss--Seidel}},
@@ -77,9 +78,7 @@ number = {2},
 pages = {593-610},
 year = {2003},
 issn = {0021-9991},
-doi = {https://doi.org/10.1016/S0021-9991(03)00194-3},
-url = {https://www.sciencedirect.com/science/article/pii/S0021999103001943},
-author = {Mark Adams and Marian Brezina and Jonathan Hu and Ray Tuminaro},
+doi = {10.1016/S0021-9991(03)00194-3},
 }
 @article{BenziOlshanskii,
 author = { Benzi, Michele and  Olshanskii, Maxim A.},
@@ -89,6 +88,7 @@ volume = {28},
 number = {6},
 pages = {2095-2113},
 year = {2006},
+doi={10.1137/050646421}
 }
 @article{BabuskaRheinboldt,
 author = {Babuška, I. and Rheinboldt, W. C.},
@@ -97,10 +97,7 @@ journal = {International Journal for Numerical Methods in Engineering},
 volume = {12},
 number = {10},
 pages = {1597-1615},
-doi = {https://doi.org/10.1002/nme.1620121010},
-url = {https://onlinelibrary.wiley.com/doi/abs/10.1002/nme.1620121010},
-eprint = {https://onlinelibrary.wiley.com/doi/pdf/10.1002/nme.1620121010},
-abstract = {Abstract Computable a-posteriori error estimates for finite element solutions are derived in an asymptotic form for h → 0 where h measures the size of the elements. The approach has similarity to the residual method but differs from it in the use of norms of negative Sobolev spaces corresponding to the given bilinear (energy) form. For clarity the presentation is restricted to one-dimensional model problems. More specifically, the source, eigenvalue, and parabolic problems are considered involving a linear, self-adjoint operator of the second order. Generalizations to more general one-dimensional problems are straightforward, and the results also extend to higher space dimensions; but this involves some additional considerations. The estimates can be used for a practical a-posteriori assessment of the accuracy of a computed finite element solution, and they provide a basis for the design of adaptive finite element solvers.},
+doi = {10.1002/nme.1620121010},
 year = {1978}
 }
 @misc{OpenCASCADE,
@@ -110,17 +107,15 @@ year = {1978}
   url = {https://www.opencascade.com/}
 }
 @article{FarrellEtAll,
-     author = {Patrick~E. Farrell and Lawrence Mitchell and L.~Ridgway Scott and Florian Wechsung},
-     title = {A {Reynolds-robust} preconditioner for the {Scott-Vogelius} discretization of the stationary incompressible {Navier-Stokes} equations},
-     journal = {The SMAI Journal of computational mathematics},
-     pages = {75--96},
-     publisher = {Soci\'et\'e de Math\'ematiques Appliqu\'ees et Industrielles},
-     volume = {7},
-     year = {2021},
-     doi = {10.5802/smai-jcm.72},
-     zbl = {07348524},
-     language = {en},
-     url = {https://smai-jcm.centre-mersenne.org/articles/10.5802/smai-jcm.72/}
+  author = {Patrick~E. Farrell and Lawrence Mitchell and L.~Ridgway Scott and Florian Wechsung},
+  title = {A {Reynolds-robust} preconditioner for the {Scott-Vogelius} discretization of the stationary incompressible {Navier-Stokes} equations},
+  journal = {The SMAI Journal of computational mathematics},
+  pages = {75--96},
+  publisher = {Soci\'et\'e de Math\'ematiques Appliqu\'ees et Industrielles},
+  volume = {7},
+  year = {2021},
+  doi = {10.5802/smai-jcm.72},
+  zbl = {07348524},
 }
 @TechReport{ml,
   AUTHOR = {M. Sala and J.J. Hu and R.S. Tuminaro},
@@ -138,6 +133,7 @@ volume = {04},
 number = {02},
 pages = {223-235},
 year = {1994},
+doi={10.1142/S0218202594000133}
 }
 @article{HT,
 title = {A numerical solution of the {Navier--Stokes} equations using the finite element technique},
@@ -148,6 +144,7 @@ pages = {73-100},
 year = {1973},
 issn = {0045-7930},
 author = {C. Taylor and P. Hood},
+doi={10.1016/0045-7930(73)90027-3}
 }
 @InProceedings{hypre,
 author="Falgout, Robert D.
@@ -161,7 +158,8 @@ booktitle="Computational Science --- ICCS 2002",
 year="2002",
 publisher="Springer Berlin Heidelberg",
 pages="632--641",
-isbn="978-3-540-47789-1"
+isbn="978-3-540-47789-1",
+doi={10.1007/3-540-47789-6_66}
 }
 @article{GMRES,
 author = {Saad, Yousef and Schultz, Martin H.},
@@ -171,12 +169,12 @@ volume = {7},
 number = {3},
 pages = {856-869},
 year = {1986},
+doi={10.1137/0907058}
 }
-
 @article{stevenson2006,
  title={Optimality of a standard adaptive finite element method},
  volume={7},
- DOI={10.1007/s10208-005-0183-0},
+ doi={10.1007/s10208-005-0183-0},
  number={2},
  journal={Foundations of Computational Mathematics},
  author={Stevenson,


### PR DESCRIPTION
We added a feature that allows you to snap the mesh in the hierarchy to the coarsest curved geometry, hence creating a nested mesh hierarchy. Example on how to use the code:

```
from firedrake import *
from netgen.occ import *
from netgen.meshing import MeshingParameters

disk1 = Circle((0, 0), 1).Face()
disk1.name = "bnd"
gelato = (disk1*HalfSpace((0,0,0),(0.2,0.6,0)))*HalfSpace((0,0,0),(0.2,-0.6,0))
geo = OCCGeometry(gelato, dim=2)
mp = MeshingParameters(minh=1.0)
ngmesh = geo.GenerateMesh(maxh=3.0, mp=mp)
mesh = Mesh(ngmesh)
mh = MeshHierarchy(mesh, 2, netgen_flags={"snap_to": "coarse", "snap_smoothing": "hyperelastic", "degree": 3})
for i in range(3):
    File(f"gelato_{i}.pvd").write(mh[i])
```
![Ref0](https://github.com/user-attachments/assets/8e78c069-1a62-47e3-8c32-463add933cb8)
![Ref1](https://github.com/user-attachments/assets/46d4ea2f-580f-4ff5-836a-6c4bc49080be)
![Ref2](https://github.com/user-attachments/assets/b5e71db6-390e-4f68-9bdb-7b041ae5591d)