### PR TITLE
UPdate dolfinx tests/api + CI

### DIFF
--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -156,6 +156,11 @@ jobs:
         run: |
           python3 -m pytest -vs ./tests/test_fenicsx.py
 
+      - name: Run tests (mpi)
+        run: |
+          mpirun -n 2 python3 -m pytest -vs ./tests/test_fenicsx.py
+
+
   fenicsx-nightly:
     runs-on: ubuntu-latest
     container:
@@ -172,5 +177,5 @@ jobs:
      
       - name: Run tests (serial)
         run: |
-          python3 -m pytest -vs ./tests/test_fenicsx.py
+          mpirun -n 2 python3 -m pytest -vs ./tests/test_fenicsx.py
 

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -137,3 +137,40 @@ jobs:
           mpirun --allow-run-as-root -n 2 pytest -m "parallel" tests/firedrake/multigrid/test_netgen_gmg.py
           pytest -m "not parallel" tests/firedrake/regression/test_netgen.py
           mpirun --allow-run-as-root -n 2 pytest -m "parallel" tests/firedrake/regression/test_netgen.py
+  
+  fenicsx-stable:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/fenicsproject/dolfinx/dolfinx:stable
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v5
+
+      - name: Install Netgen and ngsPETSc
+        run: |
+          python3 -m pip install --no-build-isolation pytest
+          python3 -m pip install .
+
+      - name: Run tests (serial)
+        run: |
+          python3 -m pytest -vs ./tests/test_fenicsx.py
+
+ fenicsx-nightly:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/fenicsproject/dolfinx/dolfinx:nightly
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v5
+
+      - name: Install Netgen and ngsPETSc
+        run: |
+          python3 -m pip install --no-build-isolation pytest
+          python3 -m pip install .
+     
+      - name: Run tests (serial)
+        run: |
+          python3 -m pytest -vs ./tests/test_fenicsx.py
+

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -141,7 +141,7 @@ jobs:
   fenicsx-stable:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/fenicsproject/dolfinx/dolfinx:stable
+      image: ghcr.io/fenics/dolfinx/dolfinx:stable
     timeout-minutes: 5
     steps:
       - name: Check out repository code
@@ -159,7 +159,7 @@ jobs:
   fenicsx-nightly:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/fenicsproject/dolfinx/dolfinx:nightly
+      image: ghcr.io/fenics/dolfinx/dolfinx:nightly
     timeout-minutes: 5
     steps:
       - name: Check out repository code

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -138,27 +138,27 @@ jobs:
           pytest -m "not parallel" tests/firedrake/regression/test_netgen.py
           mpirun --allow-run-as-root -n 2 pytest -m "parallel" tests/firedrake/regression/test_netgen.py
   
-  fenicsx-stable:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/fenics/dolfinx/dolfinx:stable
-    timeout-minutes: 10 # FIXME: Reduce this once we don't need to install petsc4py
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v5
+  # fenicsx-stable:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ghcr.io/fenics/dolfinx/dolfinx:stable
+  #   timeout-minutes: 10 # FIXME: Reduce this once we don't need to install petsc4py
+  #   steps:
+  #     - name: Check out repository code
+  #       uses: actions/checkout@v5
 
-      - name: Install Netgen and ngsPETSc
-        run: |
-          python3 -m pip install --no-build-isolation pytest poetry
-          python3 -m pip install . --check-build-dependencies --no-build-isolation
+  #     - name: Install Netgen and ngsPETSc
+  #       run: |
+  #         python3 -m pip install --no-build-isolation pytest poetry
+  #         python3 -m pip install . --check-build-dependencies --no-build-isolation
 
-      - name: Run tests (serial)
-        run: |
-          python3 -m pytest -vs ./tests/test_fenicsx.py
+  #     - name: Run tests (serial)
+  #       run: |
+  #         python3 -m pytest -vs ./tests/test_fenicsx.py
 
-      - name: Run tests (mpi)
-        run: |
-          mpirun -n 2 python3 -m pytest -vs ./tests/test_fenicsx.py
+  #     - name: Run tests (mpi)
+  #       run: |
+  #         mpirun -n 2 python3 -m pytest -vs ./tests/test_fenicsx.py
 
 
   fenicsx-nightly:

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/fenics/dolfinx/dolfinx:stable
-    timeout-minutes: 5
+    timeout-minutes: 10 # FIXME: Reduce this once we don't need to install petsc4py
     steps:
       - name: Check out repository code
         uses: actions/checkout@v5

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -87,7 +87,7 @@ jobs:
           cd /__w/ngsPETSc/ngsPETSc
           pip install --no-build-isolation xdist pytest-timeout ipympl poetry
           ls
-          pip install .
+          pip install . --no-build-isolation
 
       - name: Run part of the Firedrake test suite
         run: |
@@ -123,7 +123,7 @@ jobs:
           cd /__w/ngsPETSc/ngsPETSc
           pip install --no-build-isolation xdist pytest-timeout ipympl poetry
           ls
-          pip install .
+          pip install . --no-build-isolation
 
       - name: Run part of the Firedrake test suite
         run: |
@@ -150,7 +150,7 @@ jobs:
       - name: Install Netgen and ngsPETSc
         run: |
           python3 -m pip install --no-build-isolation pytest
-          python3 -m pip install .
+          python3 -m pip install . --no-build-isolation
 
       - name: Run tests (serial)
         run: |
@@ -168,7 +168,7 @@ jobs:
       - name: Install Netgen and ngsPETSc
         run: |
           python3 -m pip install --no-build-isolation pytest
-          python3 -m pip install .
+          python3 -m pip install . --no-build-isolation
      
       - name: Run tests (serial)
         run: |

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           python3 -m pytest -vs ./tests/test_fenicsx.py
 
- fenicsx-nightly:
+  fenicsx-nightly:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/fenicsproject/dolfinx/dolfinx:nightly

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -138,27 +138,27 @@ jobs:
           pytest -m "not parallel" tests/firedrake/regression/test_netgen.py
           mpirun --allow-run-as-root -n 2 pytest -m "parallel" tests/firedrake/regression/test_netgen.py
   
-  # fenicsx-stable:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: ghcr.io/fenics/dolfinx/dolfinx:stable
-  #   timeout-minutes: 10 # FIXME: Reduce this once we don't need to install petsc4py
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v5
+  fenicsx-stable:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/fenics/dolfinx/dolfinx:stable
+    timeout-minutes: 10 # FIXME: Reduce this once we don't need to install petsc4py
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v5
 
-  #     - name: Install Netgen and ngsPETSc
-  #       run: |
-  #         python3 -m pip install --no-build-isolation pytest poetry
-  #         python3 -m pip install . --check-build-dependencies --no-build-isolation
+      - name: Install Netgen and ngsPETSc
+        run: |
+          python3 -m pip install --no-build-isolation pytest poetry
+          python3 -m pip install . --check-build-dependencies --no-build-isolation
 
-  #     - name: Run tests (serial)
-  #       run: |
-  #         python3 -m pytest -vs ./tests/test_fenicsx.py
+      - name: Run tests (serial)
+        run: |
+          python3 -m pytest -vs ./tests/test_fenicsx.py
 
-  #     - name: Run tests (mpi)
-  #       run: |
-  #         mpirun -n 2 python3 -m pytest -vs ./tests/test_fenicsx.py
+      - name: Run tests (mpi)
+        run: |
+          mpirun -n 2 python3 -m pytest -vs ./tests/test_fenicsx.py
 
 
   fenicsx-nightly:

--- a/.github/workflows/ngsPETSc.yml
+++ b/.github/workflows/ngsPETSc.yml
@@ -149,8 +149,8 @@ jobs:
 
       - name: Install Netgen and ngsPETSc
         run: |
-          python3 -m pip install --no-build-isolation pytest
-          python3 -m pip install . --no-build-isolation
+          python3 -m pip install --no-build-isolation pytest poetry
+          python3 -m pip install . --check-build-dependencies --no-build-isolation
 
       - name: Run tests (serial)
         run: |
@@ -167,8 +167,8 @@ jobs:
 
       - name: Install Netgen and ngsPETSc
         run: |
-          python3 -m pip install --no-build-isolation pytest
-          python3 -m pip install . --no-build-isolation
+          python3 -m pip install --no-build-isolation pytest poetry
+          python3 -m pip install . --check-build-dependencies --no-build-isolation
      
       - name: Run tests (serial)
         run: |

--- a/ngsPETSc/plex.py
+++ b/ngsPETSc/plex.py
@@ -168,12 +168,12 @@ class MeshMapping:
                     T = self.ngMesh.Elements2D().NumPy()["nodes"]
 
                 if Version(np.__version__) >= Version("2.2"):
-                    T = np.trim_zeros(T, "b", axis=1).astype(np.int64) - 1
+                    T = np.trim_zeros(T, "b", axis=1).astype(np.int32) - 1
                 else:
                     T = (
                         np.array(
                             [list(np.trim_zeros(a, "b")) for a in list(T)],
-                            dtype=np.int64,
+                            dtype=np.int32,
                         )
                         - 1
                     )

--- a/ngsPETSc/utils/fenicsx.py
+++ b/ngsPETSc/utils/fenicsx.py
@@ -6,13 +6,14 @@ the package will only be used in combination with FEniCSx.
 import typing
 import dolfinx
 import numpy as np
-
+from packaging.version import Version
 from mpi4py import MPI as _MPI
 
 from ngsPETSc import MeshMapping
 
 # Map from Netgen cell type (integer tuple) to GMSH cell type
 _ngs_to_cells = {(2,3): 2, (2,4):3, (3,4): 4}
+
 
 class GeometricModel:
     """
@@ -21,16 +22,18 @@ class GeometricModel:
             geo: The Netgen model
             comm: The MPI communicator to use for mesh creation
     """
-    def __init__(self,geo, comm: _MPI.Comm):
+    def __init__(self,geo, comm: _MPI.Comm, comm_rank:int = 0):
         self.geo = geo
         self.comm = comm
+        self.comm_rank = comm_rank
 
     def model_to_mesh(self, hmax: float, gdim: int = 2,
         partitioner: typing.Callable[
         [_MPI.Comm, int, int, dolfinx.cpp.graph.AdjacencyList_int32],
         dolfinx.cpp.graph.AdjacencyList_int32] =
         dolfinx.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.none),
-        transform: typing.Any = None, routine: typing.Any = None) -> dolfinx.mesh.Mesh:
+        transform: typing.Any = None, routine: typing.Any = None
+        ) -> tuple[dolfinx.mesh.Mesh, dolfinx.mesh.MeshTags, dict[str, list[int]]]:
         """Given a NetGen model, take all physical entities of the highest
         topological dimension and create the corresponding DOLFINx mesh.
 
@@ -50,12 +53,14 @@ class GeometricModel:
         Returns:
             A DOLFINx mesh for the given NetGen model.
         """
+        # To be parallel safe, we generate on all processes
+        # NOTE: This might change in the future.
+
         # First we generate a mesh
         ngmesh = self.geo.GenerateMesh(maxh=hmax)
         # Apply any ngs routine post meshing
         if routine is not None:
             ngmesh, self.geo = routine(ngmesh, self.geo)
-        # Applying any PETSc Transform
         if transform is not None:
             meshMap = MeshMapping(ngmesh)
             transform.setDM(meshMap.plex)
@@ -63,16 +68,36 @@ class GeometricModel:
             newplex = transform.apply(meshMap.plex)
             meshMap = MeshMapping(newplex)
             ngmesh = meshMap.ngmesh
-        # We extract topology and geometry
+
+        assert ngmesh.dim in (2, 3), "Only 2D and 3D meshes are supported."
+        _dim_to_element_wrapper = {
+            1: ngmesh.Elements1D,
+            2: ngmesh.Elements2D,
+            3: ngmesh.Elements3D}
+
         V, T = None, None
-        if ngmesh.dim == 2:
+        if self.comm.rank == self.comm_rank:
+
+            # Applying any PETSc Transform
+            # We extract topology and geometry
             V = ngmesh.Coordinates()
-            T = ngmesh.Elements2D().NumPy()["nodes"]
-            T = np.array([list(np.trim_zeros(a, 'b')) for a in list(T)])-1
-        elif ngmesh.dim == 3:
-            V = ngmesh.Coordinates()
-            T = ngmesh.Elements3D().NumPy()["nodes"]
-            T = np.array([list(np.trim_zeros(a, 'b')) for a in list(T)])-1
+            T = _dim_to_element_wrapper[ngmesh.dim]().NumPy()["nodes"]
+            if Version(np.__version__) >= Version("2.2"):
+                T = np.trim_zeros(T, "b", axis=1).astype(np.int64) - 1
+            else:
+                T = (
+                    np.array(
+                        [list(np.trim_zeros(a, "b")) for a in list(T)],
+                        dtype=np.int64,
+                    )
+                    - 1
+                )
+        else:
+            # NOTE: For mixed meshes, this must change
+            V = np.zeros((0, ngmesh.dim), dtype=np.float64)
+            T = np.zeros((0, ngmesh.dim+1), dtype=np.int64)
+
+        # NOTE: Here we should curve meshes
         ufl_domain = dolfinx.io.gmshio.ufl_mesh(
             _ngs_to_cells[(gdim,T.shape[1])], gdim, dolfinx.default_real_type)
         cell_perm = dolfinx.cpp.io.perm_gmsh(dolfinx.cpp.mesh.to_type(str(ufl_domain.ufl_cell())),
@@ -80,4 +105,45 @@ class GeometricModel:
         T = np.ascontiguousarray(T[:, cell_perm])
         mesh = dolfinx.mesh.create_mesh(self.comm, cells=T, x=V, e=ufl_domain,
                                         partitioner=partitioner)
-        return mesh
+
+        if self.comm.rank == self.comm_rank:
+            regions: dict[str, list[int]] = {name: []
+                                             for name in ngmesh.GetRegionNames(dim=ngmesh.dim-1)}
+            for i, name in enumerate(ngmesh.GetRegionNames(ngmesh.dim-1), 1):
+                regions[name].append(i)
+
+            ng_facets = _dim_to_element_wrapper[ngmesh.dim-1]()
+            facet_indices = ng_facets.NumPy()["nodes"].astype(np.int64)
+            if Version(np.__version__) >= Version("2.2"):
+                facets = np.trim_zeros(facet_indices, "b", axis=1).astype(np.int64) - 1
+            else:
+                facets = (
+                    np.array(
+                        [list(np.trim_zeros(a, "b")) for a in list(facet_indices)],
+                        dtype=np.int64,
+                    )
+                    - 1
+                )
+            # Can't use the vectorized version, due to a bug in ngsolve:
+            # https://forum.ngsolve.org/t/extract-facet-markers-from-netgen-mesh/3256
+            facet_values = np.array([facet.index for facet in ng_facets], dtype=np.int32)
+            regions = self.comm.bcast(regions, root=0)
+        else:
+            # NOTE: Mixed meshes on non-simplex geometries requires changes
+            facets = np.zeros((0, ngmesh.dim), dtype=np.int64)
+            facet_values = np.zeros((0,), dtype=np.int32)
+            regions = self.comm.bcast(None, root=0)
+
+        local_entities, local_values = dolfinx.io.gmshio.distribute_entity_data(
+            mesh, mesh.topology.dim - 1, facets, facet_values
+        )
+        mesh.topology.create_connectivity(mesh.topology.dim - 1, 0)
+        adj = dolfinx.graph.adjacencylist(local_entities)
+        ft = dolfinx.mesh.meshtags_from_entities(
+            mesh,
+            mesh.topology.dim - 1,
+            adj,
+            local_values.astype(np.int32, copy=False),
+        )
+        ft.name = "Facet tags"
+        return mesh, ft, regions

--- a/ngsPETSc/utils/fenicsx.py
+++ b/ngsPETSc/utils/fenicsx.py
@@ -78,5 +78,6 @@ class GeometricModel:
         cell_perm = dolfinx.cpp.io.perm_gmsh(dolfinx.cpp.mesh.to_type(str(ufl_domain.ufl_cell())),
                                              T.shape[1])
         T = np.ascontiguousarray(T[:, cell_perm])
-        mesh = dolfinx.mesh.create_mesh(self.comm, cells=T, x=V, e=ufl_domain, partitioner=partitioner)
+        mesh = dolfinx.mesh.create_mesh(self.comm, cells=T, x=V, e=ufl_domain,
+                                        partitioner=partitioner)
         return mesh

--- a/ngsPETSc/utils/fenicsx.py
+++ b/ngsPETSc/utils/fenicsx.py
@@ -33,7 +33,7 @@ class GeometricModel:
         dolfinx.cpp.graph.AdjacencyList_int32] =
         dolfinx.mesh.create_cell_partitioner(dolfinx.mesh.GhostMode.none),
         transform: typing.Any = None, routine: typing.Any = None
-        ) -> tuple[dolfinx.mesh.Mesh, dolfinx.mesh.MeshTags, dict[str, list[int]]]:
+        ) -> tuple[dolfinx.mesh.Mesh, dolfinx.mesh.MeshTags, dict[str, tuple[int, ...]]]:
         """Given a NetGen model, take all physical entities of the highest
         topological dimension and create the corresponding DOLFINx mesh.
 
@@ -146,4 +146,7 @@ class GeometricModel:
             local_values.astype(np.int32, copy=False),
         )
         ft.name = "Facet tags"
+
+        for key, value in regions.items():
+            regions[key] = tuple(value)
         return mesh, ft, regions

--- a/ngsPETSc/utils/fenicsx.py
+++ b/ngsPETSc/utils/fenicsx.py
@@ -78,5 +78,5 @@ class GeometricModel:
         cell_perm = dolfinx.cpp.io.perm_gmsh(dolfinx.cpp.mesh.to_type(str(ufl_domain.ufl_cell())),
                                              T.shape[1])
         T = np.ascontiguousarray(T[:, cell_perm])
-        mesh = dolfinx.mesh.create_mesh(self.comm, T, V, ufl_domain, partitioner)
+        mesh = dolfinx.mesh.create_mesh(self.comm, cells=T, x=V, e=ufl_domain, partitioner=partitioner)
         return mesh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,10 @@ authors = [
   { name = "Umberto Zerbinati", email = "umberto.zerbinati@maths.ox.ac.uk" },
   { name = "Patrick E. Farrell", email = "patrick.farrell@maths.ox.ac.uk" },
   { name = "Stefano Zampini", email = "stefano.zampini@kaust.edu.sa" },
-  { name = "Jack Betteridge", email = "J.Betteridge@imperial.ac.uk" }
+  { name = "Jack Betteridge", email = "J.Betteridge@imperial.ac.uk" },
 ]
 maintainers = [
-  { name = "Umberto Zerbinati", email = "umberto.zerbinati@maths.ox.ac.uk" }
+  { name = "Umberto Zerbinati", email = "umberto.zerbinati@maths.ox.ac.uk" },
 ]
 readme = "README.md"
 license = "MIT"
@@ -22,12 +22,12 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
-  "Development Status :: 3 - Alpha"
+  "Development Status :: 3 - Alpha",
 ]
 dependencies = [
   "netgen-mesher >= 6.2,<7.0",
   "netgen-occt >=7.8,<8.0",
-  "petsc4py >=3.22.1,<4.0",
+  "petsc4py >=3.22,<4.0",
   "numpy >=2,<3",
   "scipy >=1,<2",
 ]
@@ -37,14 +37,10 @@ Documentation = "https://ngspetsc.readthedocs.io/en/latest/"
 Repository = "https://github.com/NGSolve/ngsPETSc"
 
 [project.optional-dependencies]
-firedrake = [
-  "firedrake"
-]
+firedrake = ["firedrake"]
 
 [tool.poetry]
-packages = [
-  { include = "ngsPETSc" }
-]
+packages = [{ include = "ngsPETSc" }]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3"

--- a/tests/test_fenicsx.py
+++ b/tests/test_fenicsx.py
@@ -83,7 +83,7 @@ def test_markers():
         from netgen.occ import OCCGeometry, WorkPlane, Glue
         import numpy as np
     except ImportError:
-        pytest.skip("DOLFINx unavailable, skipping FENICSx test")
+        pytest.skip("DOLFINx unavailable, skipping FENICSx test.")
 
     wp = WorkPlane()
     square = wp.Rectangle(1,1).Face()
@@ -93,7 +93,12 @@ def test_markers():
     shape = Glue([square, disk])
     geo = OCCGeometry(shape, dim=2)
     geoModel = ngfx.GeometricModel(geo, MPI.COMM_WORLD)
-    domain, (ct, ft), region_map = geoModel.model_to_mesh(hmax=0.015)
+    if dolfinx.has_kahip:
+        partitioner = dolfinx.mesh.create_cell_partitioner(dolfinx.graph.partitioner_kahip())
+    else:
+        partitioner = dolfinx.mesh.create_cell_partitioner(dolfinx.graph.partitioner_scotch())
+    domain, (ct, ft), region_map = geoModel.model_to_mesh(hmax=0.01, partitioner=partitioner)
+
     dS = ufl.Measure("dS", domain=domain, subdomain_data=ft)
 
     crack_integer_marker = region_map[(1, "circle")]

--- a/tests/test_fenicsx.py
+++ b/tests/test_fenicsx.py
@@ -3,6 +3,7 @@ This module test the utils.fenicsx class
 '''
 import pytest
 
+
 def test_square_netgen():
     '''
     Testing FEniCSx interface with Netgen generating a square mesh
@@ -18,7 +19,7 @@ def test_square_netgen():
     geo = SplineGeometry()
     geo.AddRectangle((0,0),(1,1))
     geoModel = ngfx.GeometricModel(geo, MPI.COMM_WORLD)
-    domain  =geoModel.model_to_mesh(hmax=0.1)
+    domain, _, _  = geoModel.model_to_mesh(hmax=0.1)
     with XDMFFile(domain.comm, "XDMF/mesh.xdmf", "w") as xdmf:
         xdmf.write_mesh(domain)
 
@@ -42,7 +43,7 @@ def test_poisson_netgen():
     geo = SplineGeometry()
     geo.AddRectangle((0,0),(np.pi,np.pi))
     geoModel = ngfx.GeometricModel(geo, MPI.COMM_WORLD)
-    msh  = geoModel.model_to_mesh(hmax=0.1)
+    msh, _, _  = geoModel.model_to_mesh(hmax=0.1)
     V = fem.functionspace(msh, ("Lagrange", 2)) #pylint: disable=E1120
     facetsLR = mesh.locate_entities_boundary(msh, dim=(msh.topology.dim - 1),
              marker=lambda x: np.logical_or(np.isclose(x[0], 0.0),
@@ -69,6 +70,42 @@ def test_poisson_netgen():
                   petsc_options_prefix="test_solver")
     problem.solve()
 
+
+def test_crack_netgen():
+    try:
+        from mpi4py import MPI
+        import ngsPETSc.utils.fenicsx as ngfx
+        from netgen.geom2d import CSG2d, Solid2d, EdgeInfo, Circle
+    except ImportError:
+        pytest.skip("DOLFINx unavailable, skipping FENICSx test")
+    geo = CSG2d()
+    poly = Solid2d(
+        [
+            (0, 0),
+            EdgeInfo(bc="bottom"),
+            (2, 0),
+            EdgeInfo(bc="right"),
+            (2, 2),
+            EdgeInfo(bc="topright"),
+            (1.01, 2),
+            EdgeInfo(bc="crackright"),
+            (1, 1.5),
+            EdgeInfo(bc="crackleft"),
+            (0.99, 2),
+            EdgeInfo(bc="topleft"),
+            (0, 2),
+            EdgeInfo(bc="left"),
+        ]
+    )
+
+    disk = Circle((0.3, 0.3), 0.2, bc="hole")
+    geo.Add(poly - disk)
+
+    geoModel = ngfx.GeometricModel(geo, MPI.COMM_WORLD)
+    domain, ft, region_map = geoModel.model_to_mesh(hmax=0.1)
+
+
 if __name__ == "__main__":
     test_square_netgen()
     test_poisson_netgen()
+    test_crack_netgen()

--- a/tests/test_fenicsx.py
+++ b/tests/test_fenicsx.py
@@ -59,8 +59,14 @@ def test_poisson_netgen():
     f = ufl.exp(ufl.sin(x[0])*ufl.sin(x[1]))
     a = inner(grad(u), grad(v)) * dx
     L = inner(f, v) * dx
-    problem = LinearProblem(a, L, bcs=[bc],
-              petsc_options={"ksp_type": "cg", "pc_type": "qr"})
+    # Backward compatibility
+    try:
+        problem = LinearProblem(a, L, bcs=[bc],
+                  petsc_options={"ksp_type": "cg", "pc_type": "qr"})
+    except TypeError:
+        problem = LinearProblem(a, L, bcs=[bc],
+                  petsc_options={"ksp_type": "cg", "pc_type": "qr"},
+                  petsc_options_prefix="test_solver")
     problem.solve()
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add some additional simplifications if we use modern(ish) numpy for `trim_zeros` over axis.
- Move trimming outside of topological dimension
- Add facet tags extraction in DOLFINx
- Ensure DOLFINx code works in parallel (even if "safe" mode makes it slower).
- Various fixes on CI to test dolfinx and avoid build isolation when not required (avoid petsc4py being reinstalled except in cases where it is not satisfied).