### PR TITLE
DOLFINx higher order meshes

### DIFF
--- a/ngsPETSc/utils/fenicsx.py
+++ b/ngsPETSc/utils/fenicsx.py
@@ -4,13 +4,14 @@ We adopt the same docstring conventiona as the FEniCSx project, since this part 
 the package will only be used in combination with FEniCSx.
 '''
 import typing
+import basix.ufl
 import dolfinx
 import numpy as np
 from packaging.version import Version
 from mpi4py import MPI as _MPI
-
+from ngsPETSc.utils.utils import find_permutation
 from ngsPETSc import MeshMapping
-
+import ufl
 # Map from Netgen cell type (integer tuple) to GMSH cell type
 _ngs_to_cells = {(2,3): 2, (2,4):3, (3,4): 4}
 
@@ -172,4 +173,142 @@ class GeometricModel:
 
         for key, value in regions.items():
             regions[key] = tuple(value)
+        self._mesh = mesh
+        self._tags = (ct, ft)
+        self._regions = regions
+
         return mesh, (ct, ft), regions
+
+    def curveField(self, order:int, permutation_tol:float=1e-8, location_tol:float=1e-1):
+        '''
+        This method returns a curved mesh as a Firedrake function.
+
+        :arg order: the order of the curved mesh.
+        :arg permutation_tol: tolerance used to construct the permutation of the reference element.
+        :arg location_tol: tolerance used to locate the cell a point belongs to.
+        '''
+        # Check if the mesh is a surface mesh or two dimensional mesh
+
+        _dim_to_element_wrapper = {
+            1: self.ngmesh.Elements1D,
+            2: self.ngmesh.Elements2D,
+            3: self.ngmesh.Elements3D}
+
+        ng_element = _dim_to_element_wrapper[self.ngmesh.dim]
+        ng_dimension = len(ng_element()) # Number of cells in NGS grid (on any rank)
+        geom_dim = self.ngmesh.dim
+
+
+        el = basix.ufl.element("Lagrange", self._mesh.basix_cell(), order, shape=(geom_dim, ))
+
+        rsp = el.basix_element.x # NOTE: FIX empty points in basix nanobind wrapper
+        reference_space_points = []
+        for lin in rsp:
+            if len(lin) != 0:
+                reference_space_points.append(np.vstack(lin))
+        reference_space_points = np.vstack(reference_space_points)
+
+        # Curve the mesh on rank 0 only
+        if self.comm.rank == 0:
+            # Construct numpy arrays for physical domain data
+            physical_space_points = np.zeros(
+                (ng_dimension, reference_space_points.shape[0], geom_dim)
+            )
+            curved_space_points = np.zeros(
+                (ng_dimension, reference_space_points.shape[0], geom_dim)
+            )
+            self.ngmesh.CalcElementMapping(reference_space_points, physical_space_points)
+            self.ngmesh.Curve(order)
+            self.ngmesh.CalcElementMapping(reference_space_points, curved_space_points)
+            curved = ng_element().NumPy()["curved"]
+            # Broadcast a boolean array identifying curved cells
+            curved = self.comm.bcast(curved, root=0)
+            physical_space_points = physical_space_points[curved]
+            curved_space_points = curved_space_points[curved]
+        else:
+            curved = self.comm.bcast(None, root=0)
+            # Construct numpy arrays as buffers to receive physical domain data
+            ncurved = np.sum(curved)
+            physical_space_points = np.zeros(
+                (ncurved, reference_space_points.shape[0], geom_dim)
+            )
+            curved_space_points = np.zeros(
+                (ncurved, reference_space_points.shape[0], geom_dim)
+            )
+
+        # Broadcast curved cell point data
+        self.comm.Bcast(physical_space_points, root=0)
+        self.comm.Bcast(curved_space_points, root=0)
+
+        # Get coordinates of higher order space on linarized geometry
+        X_space = dolfinx.fem.functionspace(self._mesh, el)
+        x = X_space.tabulate_dof_coordinates() # Shape (num_nodes, 3)
+        cell_map = self._mesh.topology.index_map(self._mesh.topology.dim)
+        num_cells_owned = cell_map.size_local + cell_map.num_ghosts
+        cell_node_map = X_space.dofmap.list[:num_cells_owned]
+        new_coordinates = x[cell_node_map]
+
+        # Collision detection of barycenter of cell
+        psp_shape = physical_space_points.shape
+        padded_physical_space_points = np.zeros((psp_shape[0],
+                                                 psp_shape[1], 3),
+                                                 dtype=physical_space_points.dtype)
+        padded_physical_space_points[:, :, :geom_dim] = physical_space_points
+
+        # Barycenters of curved cells (exists on all processes)
+        barycentres = np.average(padded_physical_space_points, axis=1)
+
+        # Create bounding box for function evaluation
+        bb_tree = dolfinx.geometry.bb_tree(self._mesh, self._mesh.topology.dim,
+                                           np.arange(num_cells_owned, dtype=np.int32))
+
+        # Check against standard table value
+        cell_candidates = dolfinx.geometry.compute_collisions_points(bb_tree, barycentres)
+        owned = dolfinx.geometry.compute_colliding_cells(self._mesh, cell_candidates, barycentres)
+        owned_pos = np.flatnonzero(owned.offsets[1:]-owned.offsets[:-1])
+        owned_cells = owned.array
+        assert len(owned_cells) == len(owned_pos)
+
+        # Find the correct coordinate permutation for each cell
+        if len(owned_pos) > 0:
+            owned_psp = padded_physical_space_points[owned_pos]
+            permutation = find_permutation(
+                owned_psp,
+                new_coordinates[owned_cells].reshape(
+                    owned_psp.shape
+                ).astype(self._mesh.geometry.x.dtype, copy=False),
+                tol=permutation_tol
+            )
+        else:
+            permutation = np.zeros((0, padded_physical_space_points.shape[1]), dtype=np.int64)
+        # Apply the permutation to each cell in turn
+        if len(owned_cells) > 0:
+            for ii, p in enumerate(curved_space_points[owned_pos]):
+                curved_space_points[owned_pos[ii]] = p[permutation[ii]]
+            # Assign the curved coordinates to the dat
+            x[cell_node_map[owned_cells].flatten(), :geom_dim] = curved_space_points[owned_pos].reshape(-1, geom_dim)
+
+        # Sync ghosted coordinates across all processes
+        coord_func = dolfinx.fem.Function(X_space)
+        num_dofs_local = X_space.dofmap.index_map.size_local * X_space.dofmap.index_map_bs
+        coord_func.x.array[:] = x[:num_dofs_local, :geom_dim].flatten()
+        coord_func.x.scatter_forward()
+
+        # Use topology from original mesh
+        topology = self._mesh.topology
+        # Use geometry from function_space
+        c_el = dolfinx.fem.coordinate_element(el.basix_element)
+        geom_imap = X_space.dofmap.index_map
+        local_node_indices = np.arange(geom_imap.size_local + geom_imap.num_ghosts, dtype=np.int32)
+        igi = geom_imap.local_to_global(local_node_indices)
+        geometry = dolfinx.mesh.create_geometry(geom_imap, cell_node_map, c_el._cpp_object,
+                                                coord_func.x.array.reshape(-1, geom_dim), igi)
+
+        # Create DOLFINx mesh
+        if x.dtype == np.float64:
+            cpp_mesh = dolfinx.cpp.mesh.Mesh_float64(self._mesh.comm, topology._cpp_object,
+                                                     geometry._cpp_object)
+        else:
+            raise RuntimeError(f"Unsupported dtype for mesh {x.dtype}")
+        # Wrap as Python object
+        return dolfinx.mesh.Mesh(cpp_mesh, domain=ufl.Mesh(el))

--- a/ngsPETSc/utils/fenicsx.py
+++ b/ngsPETSc/utils/fenicsx.py
@@ -201,7 +201,6 @@ class GeometricModel:
         ng_dimension = len(ng_element()) # Number of cells in NGS grid (on any rank)
         geom_dim = self.ngmesh.dim
 
-
         el = basix.ufl.element("Lagrange", self._mesh.basix_cell(), order, shape=(geom_dim, ))
 
         rsp = el.basix_element.x # NOTE: FIX empty points in basix nanobind wrapper

--- a/ngsPETSc/utils/firedrake/meshes.py
+++ b/ngsPETSc/utils/firedrake/meshes.py
@@ -11,7 +11,6 @@ except ImportError:
 
 import numpy as np
 from petsc4py import PETSc
-from scipy.spatial.distance import cdist
 
 import netgen
 import netgen.meshing as ngm

--- a/ngsPETSc/utils/firedrake/meshes.py
+++ b/ngsPETSc/utils/firedrake/meshes.py
@@ -26,6 +26,7 @@ except ImportError:
             Mesh = type(None)
 
 from ngsPETSc import MeshMapping
+from ngsPETSc.utils.utils import find_permutation
 
 def flagsUtils(flags, option, default):
     '''
@@ -79,38 +80,6 @@ def refineMarkedElements(self, mark, netgen_flags={}):
     else:
         raise NotImplementedError("No implementation for dimension other than 2 and 3.")
 
-
-@PETSc.Log.EventDecorator()
-def find_permutation(points_a, points_b, tol=1e-5):
-    """ Find all permutations between a list of two sets of points.
-
-    Given two numpy arrays of shape (ncells, npoints, dim) containing
-    floating point coordinates for each cell, determine each index
-    permutation that takes `points_a` to `points_b`. Ie:
-    ```
-    permutation = find_permutation(points_a, points_b)
-    assert np.allclose(points_a[permutation], points_b, rtol=0, atol=tol)
-    ```
-    """
-    if points_a.shape != points_b.shape:
-        raise ValueError("`points_a` and `points_b` must have the same shape.")
-
-    p = [np.where(cdist(a, b).T < tol)[1] for a, b in zip(points_a, points_b)]
-    try:
-        permutation = np.array(p, ndmin=2)
-    except ValueError as e:
-        raise ValueError(
-            "It was not possible to find a permutation for every cell"
-            " within the provided tolerance"
-        ) from e
-
-    if permutation.shape != points_a.shape[0:2]:
-        raise ValueError(
-            "It was not possible to find a permutation for every cell"
-            " within the provided tolerance"
-        )
-
-    return permutation
 
 
 @PETSc.Log.EventDecorator()

--- a/ngsPETSc/utils/utils.py
+++ b/ngsPETSc/utils/utils.py
@@ -1,0 +1,38 @@
+import numpy as np
+from petsc4py import PETSc
+from scipy.spatial.distance import cdist
+
+__all__ = ["find_permutation"]
+
+@PETSc.Log.EventDecorator()
+def find_permutation(points_a, points_b, tol=1e-5):
+    """ Find all permutations between a list of two sets of points.
+
+    Given two numpy arrays of shape (ncells, npoints, dim) containing
+    floating point coordinates for each cell, determine each index
+    permutation that takes `points_a` to `points_b`. Ie:
+    ```
+    permutation = find_permutation(points_a, points_b)
+    assert np.allclose(points_a[permutation], points_b, rtol=0, atol=tol)
+    ```
+    """
+    if points_a.shape != points_b.shape:
+        raise ValueError("`points_a` and `points_b` must have the same shape.")
+
+    p = [np.where(cdist(a, b).T < tol)[1] for a, b in zip(points_a, points_b)]
+    try:
+        permutation = np.array(p, ndmin=2)
+    except ValueError as e:
+        raise ValueError(
+            "It was not possible to find a permutation for every cell"
+            " within the provided tolerance"
+        ) from e
+
+    if permutation.shape != points_a.shape[0:2]:
+        raise ValueError(
+            "It was not possible to find a permutation for every cell"
+            " within the provided tolerance"
+        )
+
+    return permutation
+

--- a/ngsPETSc/utils/utils.py
+++ b/ngsPETSc/utils/utils.py
@@ -1,11 +1,17 @@
+"""
+Convenience functions that are FiniteElement backend independent.
+"""
+
 import numpy as np
 from petsc4py import PETSc
 from scipy.spatial.distance import cdist
+import numpy.typing as npt
 
 __all__ = ["find_permutation"]
 
 @PETSc.Log.EventDecorator()
-def find_permutation(points_a, points_b, tol=1e-5):
+def find_permutation(points_a:npt.NDArray[np.inexact], points_b:npt.NDArray[np.inexact],
+                     tol:float=1e-5):
     """ Find all permutations between a list of two sets of points.
 
     Given two numpy arrays of shape (ncells, npoints, dim) containing
@@ -35,4 +41,3 @@ def find_permutation(points_a, points_b, tol=1e-5):
         )
 
     return permutation
-


### PR DESCRIPTION
Support curving meshes made with NetGen that has been transferred to DOLFINx.
Uses the same logic as the Firedrake-meshing bit to compute the permutation.

**Implementation details**:
- The new `curved_mesh` shared the topology with the original mesh, meaning that:
    - `dolfinx.mesh.MeshTags` objects can be re-used
    - Interpolating between meshes works naturally
    - Any entity index extracted on the curved mesh (with for instance `dolfinx.mesh.locate_entities`,`dolfinx.mesh.locate_entities_boundary`) maps to the equivalent entity on the linear mesh (and vici verca).
- The new `curved_mesh` has a new `dolfinx.mesh.Geometry` based of the a vector-Lagrange space on the linear mesh. 

Due to these implementational details, it is now trivial to transfer data between the linear grid and the curved grid
```python
    mesh, (ct, ft), region_map = geoModel.model_to_mesh(hmax=0.1, partitioner=partitioner)
    curved_domain = geoModel.curveField(order)

    V = dolfinx.fem.functionspace(mesh, ("Lagrange", order))
    u = dolfinx.fem.Function(V)
    u.interpolate(lambda x: np.sin(np.pi*x[0])*np.sin(np.pi*x[1]))

    V_ref = dolfinx.fem.functionspace(curved_domain, ("Lagrange", order))
    u_ref = dolfinx.fem.Function(V_ref)
    u_ref.interpolate(u)

    with dolfinx.io.VTXWriter(mesh.comm, "u.bp", [u]) as vtx:
        vtx.write(0.0)

    with dolfinx.io.VTXWriter(curved_domain.comm, "u_curved.bp", [u_ref]) as vtx:
        vtx.write(0.0)
```
here illustrated with `order=8`.
<img width="3361" height="1698" alt="image" src="https://github.com/user-attachments/assets/6c25cc80-7518-4311-a27c-15e0d425e918" />

