### PR TITLE
Mixed Topology support with FEniCS

### DIFF
--- a/ngsPETSc/utils/fenicsx.py
+++ b/ngsPETSc/utils/fenicsx.py
@@ -148,8 +148,7 @@ class GeometricModel:
             dtype=np.int64,
         )
 
-        num_points_per_cell = number_of_vertices[type_offset[:-1]]
-
+        num_points_per_cell = number_of_vertices[sorted_index][type_offset[:-1]]
         if len(type_offset) == 2:
             mixed_mesh = False
         else:

--- a/tests/test_fenicsx.py
+++ b/tests/test_fenicsx.py
@@ -210,6 +210,7 @@ def test_mixed():
     """
     try:
         from mpi4py import MPI
+        import dolfinx
         import ngsPETSc.utils.fenicsx as ngfx
     except ImportError:
         pytest.skip("DOLFINx unavailable, skipping FENICSx test")
@@ -218,12 +219,13 @@ def test_mixed():
 
     geo = SplineGeometry()
     geo.AddCircle((0, 0), 1)
+    #geo.AddRectangle((0,0),(1,1))
     geoModel = ngfx.GeometricModel(geo, MPI.COMM_WORLD)
     domain, _, _ = geoModel.model_to_mesh(hmax=0.1, meshing_options={"quad_dominated": True})
-    import dolfinx
-    with dolfinx.io.XDMFFile(domain.comm, "XDMF/mesh.xdmf", "w") as xdmf:
+    print(domain.comm.rank, domain.comm.size, domain.topology.index_map(2).size_global,  flush=True)
+    with dolfinx.io.XDMFFile(domain.comm, "mesh.xdmf", "w") as xdmf:
         xdmf.write_mesh(domain)
-
+    print("aihfao", flush=True)
 
 if __name__ == "__main__":
     # test_square_netgen()

--- a/tests/test_fenicsx.py
+++ b/tests/test_fenicsx.py
@@ -167,7 +167,7 @@ def test_refine(order):
     gm = dolfinx.mesh.GhostMode.shared_facet
     partitioner = dolfinx.mesh.create_cell_partitioner(gm)
     if order == 1:
-        hmax = 0.03
+        hmax = 0.08
     else:
         hmax = 0.1
     mesh, (_, _), region_map = geoModel.model_to_mesh(
@@ -199,7 +199,7 @@ def test_refine(order):
     inner = refined_mesh.comm.allreduce(local_inner, op=MPI.SUM)
     outer = refined_mesh.comm.allreduce(local_outer, op=MPI.SUM)
     if order == 1:
-        tol = 1e-3
+        tol = 5e-3
     else:
         tol = 5e-5
     assert np.isclose(

--- a/tests/test_fenicsx.py
+++ b/tests/test_fenicsx.py
@@ -2,6 +2,8 @@
 This module test the utils.fenicsx class
 """
 
+import basix
+import numpy as np
 import pytest
 from packaging.version import Version
 
@@ -231,8 +233,17 @@ def test_mixed():
         dolfinx.graph.partitioner_kahip(), dolfinx.mesh.GhostMode.none
     )
     domain, _, _ = geoModel.model_to_mesh(
-        hmax=0.03, meshing_options={"quad_dominated": False}, partitioner=part, gdim=2
+        hmax=0.3, meshing_options={"quad_dominated": True}, partitioner=part, gdim=2
     )
+    domain = geoModel.curveField(2)
+    from dolfinx.io.vtkhdf import write_mesh
+
+    write_mesh("mixed_mesh.vtkhdf", domain)
+
+    # print(domain.comm.rank, domain.comm.size, domain.topology.index_map(2).size_global,  flush=True)
+    # with dolfinx.io.XDMFFile(domain.comm, "mesh.xdmf", "w") as xdmf:
+    #     xdmf.write_mesh(domain)
+
 
 if __name__ == "__main__":
     # test_square_netgen()

--- a/tests/test_fenicsx.py
+++ b/tests/test_fenicsx.py
@@ -1,9 +1,6 @@
 """
 This module test the utils.fenicsx class
 """
-
-import basix
-import numpy as np
 import pytest
 from packaging.version import Version
 
@@ -226,28 +223,24 @@ def test_mixed():
     from netgen.geom2d import SplineGeometry
 
     geo = SplineGeometry()
-    geo.AddCircle((0, 0), 1)
+    geo.AddCircle((1, 1.2), 1)
     # geo.AddRectangle((0,0),(1,1))
     geoModel = ngfx.GeometricModel(geo, MPI.COMM_WORLD)
     part = dolfinx.mesh.create_cell_partitioner(
         dolfinx.graph.partitioner_kahip(), dolfinx.mesh.GhostMode.none
     )
     domain, _, _ = geoModel.model_to_mesh(
-        hmax=0.3, meshing_options={"quad_dominated": True}, partitioner=part, gdim=2
+        hmax=0.4, meshing_options={"quad_dominated": True}, partitioner=part, gdim=2
     )
     domain = geoModel.curveField(2)
     from dolfinx.io.vtkhdf import write_mesh
 
     write_mesh("mixed_mesh.vtkhdf", domain)
 
-    # print(domain.comm.rank, domain.comm.size, domain.topology.index_map(2).size_global,  flush=True)
-    # with dolfinx.io.XDMFFile(domain.comm, "mesh.xdmf", "w") as xdmf:
-    #     xdmf.write_mesh(domain)
-
 
 if __name__ == "__main__":
-    # test_square_netgen()
-    # test_poisson_netgen()
-    # test_markers(2)
-    # test_refine(3)
+    test_square_netgen()
+    test_poisson_netgen()
+    test_markers(2)
+    test_refine(3)
     test_mixed()


### PR DESCRIPTION
One can now read and write first and 2nd order mixed topology grids from ngsolve to DOLFINx
<img width="825" height="751" alt="image" src="https://github.com/user-attachments/assets/d260282e-6e08-4fed-8a64-8c18fe37cb5a" />

Also a major refactoring, keeping track of the original ngsolve cell index, rather than doing an expensive collision detection.