### PR TITLE
Make gmshio backward compat mode

### DIFF
--- a/ngsPETSc/utils/fenicsx.py
+++ b/ngsPETSc/utils/fenicsx.py
@@ -254,6 +254,7 @@ class GeometricModel:
                 c_els,
                 V,
                 partitioner,
+                2  # Maximum number of cells connected to any facet
             )
             # Wrap as Python object
             mesh = dolfinx.mesh.Mesh(cpp_mesh, domain=None)


### PR DESCRIPTION
Make sure we can use NGSPETSc with DOLFINx main, where
`dolfinx.io.gmshio` has been renamed to `dolfinx.io.gmsh`.

Additionally, add extra input argument to mixed mesh constructor, as it now can take in `max_number_of_cells_connected_to_any_facet`.