### PR TITLE
Cast Netgen coordinates to PetscReal in createPETScDMPlex

### DIFF
--- a/ngsPETSc/plex.py
+++ b/ngsPETSc/plex.py
@@ -199,7 +199,12 @@ def createPETScDMPlex(ngMesh, comm, name):
     tdim = comm.bcast(tdim, root=0)
     if comm.rank == 0:
         cells_np = cells.NumPy()
-        V = ngMesh.Coordinates()
+        # Netgen always stores coordinates as float64. createFromCellList performs
+        # a "safe" cast to PetscReal, which rejects a float64 -> float32 narrowing
+        # in single-precision PETSc builds, so cast explicitly here. This is a
+        # no-op when PetscReal is double (the rank != 0 branch below already builds
+        # its empty coordinate array with PETSc.RealType for the same reason).
+        V = ngMesh.Coordinates().astype(PETSc.RealType, copy=False)
         T = trim_util(cells_np["nodes"])
         plex = PETSc.DMPlex().createFromCellList(tdim, T, V, comm=comm)
         vStart, _ = plex.getDepthStratum(0)


### PR DESCRIPTION
## Summary

`createPETScDMPlex` passes Netgen's coordinates straight to
`DMPlex.createFromCellList` on rank 0. Netgen always stores coordinates as
`float64`, and `createFromCellList` performs a "safe" cast to `PetscReal` that
rejects a `float64 -> float32` narrowing. As a result every Netgen mesh
construction fails in single-precision PETSc builds (`--with-precision=single`).

This casts the rank-0 coordinates to `PETSc.RealType` (`copy=False`, so it is a
no-op when `PetscReal` is double). The rank != 0 branch already builds its empty
coordinate array with `PETSc.RealType`, so this just makes the two paths
consistent.

## Context

Found while adding single-precision support to Firedrake
(firedrakeproject/firedrake#5033); this fixes the `test_netgen.py` failures in
that build.

## Test plan

- [x] `make lint` passes (10.00/10) with the repository pylint configuration.
- [ ] Existing double-precision CI is unaffected (the cast is a no-op when
      `PetscReal` is double).
- [ ] Netgen mesh construction succeeds against a single-precision PETSc build.

Made with [Cursor](https://cursor.com)